### PR TITLE
Fixed unescapped backslashes

### DIFF
--- a/en/reference/annotations.rst
+++ b/en/reference/annotations.rst
@@ -50,10 +50,10 @@ Take a look at the following code snippet:
 
 In this snippet you can see a variety of different docblock annotations:
 
-- Documentation annotations such as @var and @author. These annotations are on a blacklist and never considered for throwing an exception due to wrongly used annotations.
-- Annotations imported through use statements. The statement ``use Doctrine\ORM\Mapping AS ORM`` makes all classes under that namespace available as @ORM\\ClassName. Same goes for the import of "Assert".
-- The @dummy annotation. It is not a documentation annotation and not blacklisted. For Doctrine Annotations it is not entirely clear how to handle this annotation. Depending on the configuration an exception (unknown annotation) will be thrown when parsing this annotation.
-- The fully qualified annotation @MyProject\\Annotations\\Foobarable. This is transformed directly into the given class name.
+- Documentation annotations such as ``@var`` and ``@author``. These annotations are on a blacklist and never considered for throwing an exception due to wrongly used annotations.
+- Annotations imported through use statements. The statement ``use Doctrine\ORM\Mapping AS ORM`` makes all classes under that namespace available as ``@ORM\ClassName``. Same goes for the import of ``@Assert``.
+- The ``@dummy`` annotation. It is not a documentation annotation and not blacklisted. For Doctrine Annotations it is not entirely clear how to handle this annotation. Depending on the configuration an exception (unknown annotation) will be thrown when parsing this annotation.
+- The fully qualified annotation ``@MyProject\Annotations\Foobarable``. This is transformed directly into the given class name.
 
 How are these annotations loaded? From looking at the code you could guess that the ORM Mapping, Assert Validation and the fully qualified annotation can just be loaded using
 the defined PHP autoloaders. This is not the case however: For error handling reasons every check for class existence inside the AnnotationReader sets the second parameter $autoload
@@ -84,7 +84,7 @@ Doctrine saves all its annotations in a single file, that is why ``AnnotationReg
 ``AnnotationRegistry#registerAutoloadNamespace`` which creates a PSR-0 compatible loading mechanism for class to file names.
 
 In the third block, we create the actual AnnotationReader instance. Note that we also add "dummy" to the global list of annotations
-for which we do not throw exceptions. Setting this is necessary in our example case, otherwise @dummy would trigger an exception to
+for which we do not throw exceptions. Setting this is necessary in our example case, otherwise ``@dummy`` would trigger an exception to
 be thrown during the parsing of the docblock of ``MyProject\Entities\User#id``.
 
 Setup and Configuration
@@ -287,7 +287,7 @@ Annotation Classes
 ------------------
 
 If you want to define your own annotations you just have to group them in a namespace and register this namespace
-in the AnnotationRegistry. Annotation classes have to contain a class-level docblock with the text @Annotation:
+in the AnnotationRegistry. Annotation classes have to contain a class-level docblock with the text ``@Annotation``:
 
 .. code-block :: php
 


### PR DESCRIPTION
Annotations were not rendered correctly because the backslashes were not escaped. I also think they should be placed in literals.
