### PR TITLE
Fixes to caching docs: renamed $id to something more representative, checking value against false to detect cache miss

### DIFF
--- a/en/reference/caching.rst
+++ b/en/reference/caching.rst
@@ -31,10 +31,10 @@ of the request can be found below.
     <?php
 
     $cache = new \Doctrine\Common\Cache\ArrayCache();
-    $id = $cache->fetch("some key");
-    if (!$id) {
-        $id = do_something();
-        $cache->save("some key", $id);
+    $data = $cache->fetch("some key");
+    if ($data === false) {
+        $data = do_something();
+        $cache->save("some key", $data);
     }
 
     ..


### PR DESCRIPTION
Changed $id to $data, since that's what it really is.
Changed if (!$id) to if ($id === false), since '' or 0 would evaluate as a cache miss when either could be a perfectly valid value.